### PR TITLE
Add `HasCharacterLimit` Trait and Update README

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,6 +21,7 @@ use it in your resource
     ->default(3)
     ->maxValue(10)
     ->minValue(2)
+    ->characterLimit(2)
     ->stacked()
     
     ->label('select quantity')
@@ -29,6 +30,7 @@ use it in your resource
     ->disabled()
     ->hiddenLabel()
     ->helperText('between 2 and 10')
+    ->characterLimit(2)
     ->columnSpan(1)
     ,
 ```

--- a/src/Components/Quantity.php
+++ b/src/Components/Quantity.php
@@ -5,11 +5,13 @@ namespace LaraZeus\Quantity\Components;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Concerns\HasName;
 use LaraZeus\Quantity\Traits\HasCharacterLimit;
+use LaraZeus\Quantity\Traits\CanBeShownInsideControl;
 
 class Quantity extends TextInput
 {
     use HasName;
     use HasCharacterLimit;
+    use CanBeShownInsideControl;
 
     public ?string $heading = null;
 

--- a/src/Components/Quantity.php
+++ b/src/Components/Quantity.php
@@ -2,12 +2,14 @@
 
 namespace LaraZeus\Quantity\Components;
 
-use Filament\Forms\Components\Concerns\HasName;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Concerns\HasName;
+use LaraZeus\Quantity\Traits\HasCharacterLimit;
 
 class Quantity extends TextInput
 {
     use HasName;
+    use HasCharacterLimit;
 
     public ?string $heading = null;
 

--- a/src/Traits/CanBeShownInsideControl.php
+++ b/src/Traits/CanBeShownInsideControl.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaraZeus\Quantity\Traits;
+
+use Closure;
+
+trait CanBeShownInsideControl
+{
+    protected bool | Closure $isShownInsideControl = false;
+
+    public function showInsideControl(bool | Closure $condition = true): static
+    {
+        $this->isShownInsideControl = $condition;
+
+        return $this;
+    }
+
+    public function isShownInsideControl(): bool
+    {
+        return (bool) $this->evaluate($this->isShownInsideControl);
+    }
+}

--- a/src/Traits/HasCharacterLimit.php
+++ b/src/Traits/HasCharacterLimit.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaraZeus\Quantity\Traits;
+
+use Closure;
+
+trait HasCharacterLimit
+{
+    protected int | Closure | null $characterLimit = 0;
+
+    public function characterLimit(int | Closure | null $value = null): self
+    {
+        $this->characterLimit = $value;
+
+        return $this;
+    }
+
+    public function getCharacterLimit(): ?int
+    {
+        $character_limit = (int) $this->evaluate($this->characterLimit);
+
+        if ($this->maxLength && $character_limit === 0) {
+            return $this->getMaxLength();
+        }
+
+        return $character_limit;
+    }
+}


### PR DESCRIPTION

## Summary

This pull request introduces the `HasCharacterLimit` trait and updates the README documentation to reflect this new feature.

## Changes
- Added `HasCharacterLimit` trait to the `LaraZeus\Quantity\Traits` component.
- Updated the README with instructions on how to use the `characterLimit` method.

## Usage
To set a character limit on the `amount_number` field, use the `characterLimit` method as shown below:

```php
\LaraZeus\Quantity\Components\Quantity::make('amount_number')
    ->heading('Select Quantity')
    ->default(3)
    ->maxValue(10)
    ->minValue(2)
    ->characterLimit(2) // Add this line to set the character limit
    ->stacked();